### PR TITLE
Ability to add tasks to an existing module

### DIFF
--- a/raft/_version.py
+++ b/raft/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 4, 1, 1)
+__version_info__ = (1, 4, 1, 2)
 __version__ = ".".join(map(str, __version_info__))

--- a/raft/collection.py
+++ b/raft/collection.py
@@ -226,14 +226,21 @@ class Collection(object):
                 ret._configuration = obj_config
                 return ret
         # Failing that, make our own collection from the module's tasks.
-        tasks = filter(lambda x: isinstance(x, Task), vars(module).values())
         # Again, explicit name wins over implicit one from module path
         collection = instantiate()
-        for task in tasks:
-            collection.add_task(task)
+        collection.add_tasks(module)
         if config:
             collection.configure(config)
         return collection
+
+    def add_tasks(self, module):
+        """
+        Adds one or more tasks to this Collection from a module
+        """
+        tasks = filter(lambda x: isinstance(x, Task), vars(module).values())
+        for task in tasks:
+            self.add_task(task)
+
 
     def add_task(self, task, name=None, aliases=None, default=None):
         """


### PR DESCRIPTION
## Problem?

Because single files can get very large for complicated convocations,
We will often want to add tasks from multiple modules to a single
collection.

## Solution!

Added a helper function that would add all tasks from a given module to
an existing collection.